### PR TITLE
Miner self-optimizes and prints more neatly

### DIFF
--- a/gpu-miner.c
+++ b/gpu-miner.c
@@ -12,54 +12,37 @@
 #endif
  
 #define MAX_SOURCE_SIZE (0x200000)
-#define THREADS_PER_COMPUTE_UNIT 192
-#define THREAD_MULT 16
-/* GPU does MAX_COMPUTE_UNITS * THREADS_PERCOMPUTE_UNIT * THREAD_MULT threads.
- * Maxes out at 256 * 256 threads to make nonce grinding simpler for now.
- * Using such a large number of threads helps ensure that every core stays busy.
- * It can be faster to have less threads with each doing more work, but only if you know the right number
- * of threads for your GPU. If you get this number wrong, it can severely impact performance.
- * Using this method usually gets 85-95% hashing power out of the GPU.
- * Using a lower, non-optimized number of threads can result in as low as 60% hashing power.
- * TODO: Write code that finds the 'optimal' thread count on host GPU to get 95-100% hashing power
- */
- 
+
+double grindNonces(size_t global_item_size, size_t iter_per_thread);
+
+cl_command_queue command_queue = NULL;
+cl_mem blockHeadermobj = NULL;
+cl_mem headerHashmobj = NULL;
+cl_mem targmobj = NULL;
+cl_mem nonceOutmobj = NULL;
+cl_mem nonceOutLockmobj = NULL;
+cl_mem iter_per_threadmobj = NULL;
+cl_kernel kernel = NULL;
+cl_int ret;
+
+CURL *curl;
+
+
 int main() {   
 	cl_platform_id platform_id = NULL;
 	cl_device_id device_id = NULL;
 	cl_context context = NULL;
-	cl_command_queue command_queue = NULL;
-	cl_mem blockHeadermobj = NULL;
-	cl_mem headerHashmobj = NULL;
-	cl_mem targmobj = NULL;
-	cl_mem nonceOutmobj = NULL;	
-	cl_mem nonceOutLockmobj = NULL;	
-	cl_mem numItersPerThreadmobj = NULL;
 	cl_program program = NULL;
-	cl_kernel kernel = NULL;	
 	cl_uint ret_num_devices;
 	cl_uint ret_num_platforms;
-	cl_int ret;
+ 
+	int i;
 	int max_compute_units;
+	size_t global_item_size = 1;
+	size_t iter_per_thread = 256 * 16; // This must be a multiple of 256 and no more than 256 * 256
 
 	// Use curl to communicate with siad
-	CURL *curl = curl_easy_init();
- 
- 	// Initialize the kernel's input data.
-	int i;
-	uint8_t blockHeader[80];
-	uint8_t headerHash[32];
-	uint8_t target[32];
-	uint8_t nonceOut[8]; // This is where the nonce that gets a low enough hash will be stored
-	uint8_t nonceOutLock = 0;
-	uint32_t numItersPerThread = 256 * 16; // This must be a multiple of 256 and no more than 256 * 256
-
-	// Store block from siad
-	uint8_t *block;
-	size_t blocklen = 0;
-
-	for (i = 0; i < 8; i++)
-		nonceOut[i] = 0;
+	curl = curl_easy_init();
 
 	// Load kernel source file
 	FILE *fp;
@@ -68,7 +51,7 @@ int main() {
 	char *source_str;
 	fp = fopen(fileName, "r");
 	if (!fp) {
-		fprintf(stderr, "Failed to load kernel.\n");	
+		fprintf(stderr, "Failed to load kernel.\n");
 		exit(1);
 	}
 	source_str = (char *)malloc(MAX_SOURCE_SIZE);
@@ -77,17 +60,12 @@ int main() {
 
 	// Get Platform/Device Information
 	ret = clGetPlatformIDs(1, &platform_id, &ret_num_platforms);
-	if (ret != CL_SUCCESS) { printf("failed to get platform IDs: %d\n", ret); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to get platform IDs: %d\n", ret); exit(1); }
 	ret = clGetDeviceIDs(platform_id, CL_DEVICE_TYPE_GPU, 1, &device_id, &ret_num_devices);
-	if (ret != CL_SUCCESS) { printf("failed to get Device IDs: %d\n", ret); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to get Device IDs: %d\n", ret); exit(1); }
 	ret = clGetDeviceInfo(device_id, CL_DEVICE_MAX_COMPUTE_UNITS, sizeof(int), &max_compute_units, NULL);
-	if (ret != CL_SUCCESS) { printf("failed to get device max compute units: %d\n", ret); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to get device max compute units: %d\n", ret); exit(1); }
 	printf("Device max compute units:\t%d\n", max_compute_units);
-
-	// Set number of threads to run
-	size_t global_item_size = max_compute_units * THREADS_PER_COMPUTE_UNIT * THREAD_MULT;
-	if (global_item_size > 65536)
-		global_item_size = 65536;
 
 	// Create OpenCL Context
 	context = clCreateContext(NULL, 1, &device_id, NULL, NULL, &ret);
@@ -97,17 +75,17 @@ int main() {
 
 	// Create Buffer Objects
 	blockHeadermobj = clCreateBuffer(context, CL_MEM_READ_WRITE, 80 * sizeof(uint8_t), NULL, &ret);
-	if (ret != CL_SUCCESS) { printf("failed to create blockHeadermobj buffer: %d\n", ret); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to create blockHeadermobj buffer: %d\n", ret); exit(1); }
 	headerHashmobj = clCreateBuffer(context, CL_MEM_READ_WRITE, 32 * sizeof(uint8_t), NULL, &ret);
-	if (ret != CL_SUCCESS) { printf("failed to create targmobj buffer: %d\n", ret); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to create targmobj buffer: %d\n", ret); exit(1); }
 	targmobj = clCreateBuffer(context, CL_MEM_READ_WRITE, 32 * sizeof(uint8_t), NULL, &ret);
-	if (ret != CL_SUCCESS) { printf("failed to create targmobj buffer: %d\n", ret); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to create targmobj buffer: %d\n", ret); exit(1); }
 	nonceOutmobj = clCreateBuffer(context, CL_MEM_READ_WRITE, 8 * sizeof(uint8_t), NULL, &ret);
-	if (ret != CL_SUCCESS) { printf("failed to create nonceOutmobj buffer: %d\n", ret); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to create nonceOutmobj buffer: %d\n", ret); exit(1); }
 	nonceOutLockmobj = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(uint8_t), NULL, &ret);
-	if (ret != CL_SUCCESS) { printf("failed to create nonceOutmobj buffer: %d\n", ret); return -1; }
-	numItersPerThreadmobj = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(uint32_t), NULL, &ret);
-	if (ret != CL_SUCCESS) { printf("failed to create numItersPerThreadmobj buffer: %d\n", ret); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to create nonceOutmobj buffer: %d\n", ret); exit(1); }
+	iter_per_threadmobj = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(uint32_t), NULL, &ret);
+	if (ret != CL_SUCCESS) { printf("failed to create iter_per_threadmobj buffer: %d\n", ret); exit(1); }
 
 	// Create kernel program from source file
 	program = clCreateProgramWithSource(context, 1, (const char **)&source_str, (const size_t *)&source_size, &ret);
@@ -152,95 +130,65 @@ int main() {
 
 	// Set OpenCL kernel arguments
 	ret = clSetKernelArg(kernel, 0, sizeof(cl_mem), (void *)&blockHeadermobj);
-	if (ret != CL_SUCCESS) { printf("failed to set first kernel arg: \n"); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to set first kernel arg: \n"); exit(1); }
 	ret = clSetKernelArg(kernel, 1, sizeof(cl_mem), (void *)&headerHashmobj);
-	if (ret != CL_SUCCESS) { printf("failed to set fifth kernel arg: \n"); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to set fifth kernel arg: \n"); exit(1); }
 	ret = clSetKernelArg(kernel, 2, sizeof(cl_mem), (void *)&targmobj);
-	if (ret != CL_SUCCESS) { printf("failed to set third kernel arg: \n"); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to set third kernel arg: \n"); exit(1); }
 	ret = clSetKernelArg(kernel, 3, sizeof(cl_mem), (void *)&nonceOutmobj);
-	if (ret != CL_SUCCESS) { printf("failed to set second kernel arg: \n"); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to set second kernel arg: \n"); exit(1); }
 	ret = clSetKernelArg(kernel, 4, sizeof(cl_mem), (void *)&nonceOutLockmobj);
-	if (ret != CL_SUCCESS) { printf("failed to set fourth kernel arg: \n"); return -1; }
-	ret = clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *)&numItersPerThreadmobj);
-	if (ret != CL_SUCCESS) { printf("failed to set fourth kernel arg: \n"); return -1; }
+	if (ret != CL_SUCCESS) { printf("failed to set fourth kernel arg: \n"); exit(1); }
+	ret = clSetKernelArg(kernel, 5, sizeof(cl_mem), (void *)&iter_per_threadmobj);
+	if (ret != CL_SUCCESS) { printf("failed to set fourth kernel arg: \n"); exit(1); }
 
-	// Mine blocks until program is interrupted
-	// Each iteration of the loop should take 1-3 seconds
-	while (1) {
-		// Start timing this iteration
-		clock_t startTime = clock();
-
-		// Get new block header and target
-		get_block_for_work(curl, target, blockHeader, &block, &blocklen);
-
-		// Reset hash
-		for (i = 0; i < 32; i++)
-			headerHash[i] = 255;
-
-		nonceOutLock = 0;
-
-		// Copy input data to the memory buffer
-		ret = clEnqueueWriteBuffer(command_queue, blockHeadermobj, CL_TRUE, 0, 80 * sizeof(uint8_t), blockHeader, 0, NULL, NULL);
-		if (ret != CL_SUCCESS) { printf("failed to write to blockHeadermobj buffer: %d\n", ret); return -1; }
-		ret = clEnqueueWriteBuffer(command_queue, headerHashmobj, CL_TRUE, 0, 32 * sizeof(uint8_t), headerHash, 0, NULL, NULL);
-		if (ret != CL_SUCCESS) { printf("failed to write to targmobj buffer: %d\n", ret); return -1; }
-		ret = clEnqueueWriteBuffer(command_queue, targmobj, CL_TRUE, 0, 32 * sizeof(uint8_t), target, 0, NULL, NULL);
-		if (ret != CL_SUCCESS) { printf("failed to write to targmobj buffer: %d\n", ret); return -1; }
-		ret = clEnqueueWriteBuffer(command_queue, nonceOutLockmobj, CL_TRUE, 0, sizeof(uint8_t), &nonceOutLock, 0, NULL, NULL);
-		if (ret != CL_SUCCESS) { printf("failed to write to nonceOutLockmobj buffer: %d\n", ret); return -1; }
-		ret = clEnqueueWriteBuffer(command_queue, numItersPerThreadmobj, CL_TRUE, 0, sizeof(uint32_t), &numItersPerThread, 0, NULL, NULL);
-		if (ret != CL_SUCCESS) { printf("failed to write to targmobj buffer: %d\n", ret); return -1; }
-
-		// Execute OpenCL kernel as data parallel
-		printf("Starting %zd threads.\n", global_item_size);
-		ret = clEnqueueNDRangeKernel(command_queue, kernel, 1, NULL, &global_item_size, NULL, 0, NULL, NULL);
-		if (ret != CL_SUCCESS) { printf("failed to start kernel: %d\n", ret); return -1; }
-
-		// Copy result to host
-		ret = clEnqueueReadBuffer(command_queue, headerHashmobj, CL_TRUE, 0, 32 * sizeof(uint8_t), headerHash, 0, NULL, NULL);
-		if (ret != CL_SUCCESS) { printf("failed to read header hash from buffer: %d\n", ret); return -1; }
-		ret = clEnqueueReadBuffer(command_queue, nonceOutmobj, CL_TRUE, 0, 8 * sizeof(uint8_t), nonceOut, 0, NULL, NULL);
-		if (ret != CL_SUCCESS) { printf("failed to read nonce from buffer: %d\n", ret); return -1; }
-
-		// Did we find one?
-		i = 0;
-		while (target[i] == headerHash[i])
-			i++;
-		if (headerHash[i] < target[i]) {
-			// Display some info about the hash that was found
-			printf("Thread %u found a good hash!\n", nonceOut[0] * 256 + nonceOut[1]);
-
-			printf("Header: [");
-			for (i = 0; i < 10; i++) {
-				printf("%u ", blockHeader[i]);
-			}
-			printf("... %u]\n", blockHeader[79]);
-
-			printf("Hash: [");
-			for (i = 0; i < 10; i++) {
-				printf("%u ", headerHash[i]);
-			}
-			printf("... %u]\n", headerHash[31]);
-
-			printf("Nonce: [");
-			for (i = 0; i < 7; i++) {
-				printf("%u ", nonceOut[i]);
-			}
-			printf("%u]\n", nonceOut[7]);
-			
-			// Copy nonce to block
-			for (i = 0; i < 8; i++)
-				block[i + 32] = nonceOut[i];
-
-			submit_block(curl, block, blocklen);
-			printf("\n");
-		} else {
-			printf("No hash was found. Fetching new block.\n");
-			// Hashrate is inaccurate if a block was found
-			double run_time_seconds = (double)(clock() - startTime) / CLOCKS_PER_SEC;
-			printf("Mined for %.2f seconds at %.3f MH/s\n\n", run_time_seconds, (numItersPerThread*global_item_size) / (run_time_seconds*1000000));
-			// TODO: Print est time until next block (target difficulty / hashrate
+	// Rough scan for 'optimal' thread count
+	double prev_hash_rate = 0;
+	global_item_size = 16;
+	iter_per_thread = 16 * 256;
+	while(1) {
+		global_item_size *= 2;
+		double hash_rate = grindNonces(global_item_size, iter_per_thread);
+		while (hash_rate == -1) {
+			// Repeat until no block is found
+			hash_rate = grindNonces(global_item_size, iter_per_thread);
 		}
+		if (hash_rate < prev_hash_rate) {
+			break;
+		}
+		prev_hash_rate = hash_rate;
+	}
+	printf("Rough search found %zd threads to be the best at %.3f MH/s\n", global_item_size/2, prev_hash_rate);
+
+	// Now we know the optimal is betweem global_item_size and global_item_size / 2
+	// Scan intermediate 16 values and pick the highest
+	int dec = (global_item_size - global_item_size / 2) / 16;
+	double best_hash_rate = prev_hash_rate;
+	size_t best_item_size = global_item_size / 2;
+	for (i = 0; i < 16; i++) {
+		global_item_size -= dec;
+		double hash_rate = grindNonces(global_item_size, iter_per_thread);
+		while (hash_rate == -1) {
+			// Repeat until no block is found
+			hash_rate = grindNonces(global_item_size, iter_per_thread);
+		}
+		if (hash_rate > best_hash_rate) {
+			best_hash_rate = hash_rate;
+			best_item_size = global_item_size;
+		}
+	}
+	global_item_size = best_item_size;
+	printf("Fine search found %zd threads to be the best at %.3f MH/s\n", global_item_size, best_hash_rate);
+
+	// Make each iteration take about 3 seconds
+	clock_t startTime = clock();
+	grindNonces(global_item_size, iter_per_thread);
+	double run_time_seconds = (double)(clock() - startTime) / CLOCKS_PER_SEC;
+	iter_per_thread *= 3 / run_time_seconds;
+
+	// Grind nonces endlessly using
+	while (1) {
+		grindNonces(global_item_size, iter_per_thread);
 	}
 	
 	// Finalization
@@ -252,7 +200,7 @@ int main() {
 	ret = clReleaseMemObject(targmobj);
 	ret = clReleaseMemObject(nonceOutmobj);
 	ret = clReleaseMemObject(nonceOutLockmobj);
-	ret = clReleaseMemObject(numItersPerThreadmobj);
+	ret = clReleaseMemObject(iter_per_threadmobj);
 	ret = clReleaseCommandQueue(command_queue);
 	ret = clReleaseContext(context);	
  
@@ -261,4 +209,99 @@ int main() {
 	free(source_str);
  
 	return 0;
+}
+
+// Perform global_item_size * iter_per_thread hashes
+// Return -1 if a block is found
+// Else return the hashrate in MH/s
+double grindNonces(size_t global_item_size, size_t iter_per_thread) {
+	uint8_t blockHeader[80];
+	uint8_t headerHash[32];
+	uint8_t target[32];
+	uint8_t nonceOut[8]; // This is where the nonce that gets a low enough hash will be stored
+	uint8_t nonceOutLock = 0;
+
+	int i;
+	for (i = 0; i < 8; i++)
+		nonceOut[i] = 0;
+
+	// Max out hash
+	for (i = 0; i < 32; i++)
+		headerHash[i] = 255;
+
+	// Store block from siad
+	uint8_t *block;
+	size_t blocklen = 0;
+
+	// Get new block header and target
+	get_block_for_work(curl, target, blockHeader, &block, &blocklen);
+
+	// Start timing this iteration
+	clock_t startTime = clock();
+
+	// Copy input data to the memory buffer
+	ret = clEnqueueWriteBuffer(command_queue, blockHeadermobj, CL_TRUE, 0, 80 * sizeof(uint8_t), blockHeader, 0, NULL, NULL);
+	if (ret != CL_SUCCESS) { printf("failed to write to blockHeadermobj buffer: %d\n", ret); exit(1); }
+	ret = clEnqueueWriteBuffer(command_queue, headerHashmobj, CL_TRUE, 0, 32 * sizeof(uint8_t), headerHash, 0, NULL, NULL);
+	if (ret != CL_SUCCESS) { printf("failed to write to targmobj buffer: %d\n", ret); exit(1); }
+	ret = clEnqueueWriteBuffer(command_queue, targmobj, CL_TRUE, 0, 32 * sizeof(uint8_t), target, 0, NULL, NULL);
+	if (ret != CL_SUCCESS) { printf("failed to write to targmobj buffer: %d\n", ret); exit(1); }
+	ret = clEnqueueWriteBuffer(command_queue, nonceOutLockmobj, CL_TRUE, 0, sizeof(uint8_t), &nonceOutLock, 0, NULL, NULL);
+	if (ret != CL_SUCCESS) { printf("failed to write to nonceOutLockmobj buffer: %d\n", ret); exit(1); }
+	ret = clEnqueueWriteBuffer(command_queue, iter_per_threadmobj, CL_TRUE, 0, sizeof(uint32_t), &iter_per_thread, 0, NULL, NULL);
+	if (ret != CL_SUCCESS) { printf("failed to write to targmobj buffer: %d\n", ret); exit(1); }
+
+	// Execute OpenCL kernel as data parallel
+	ret = clEnqueueNDRangeKernel(command_queue, kernel, 1, NULL, &global_item_size, NULL, 0, NULL, NULL);
+	if (ret != CL_SUCCESS) { printf("failed to start kernel: %d\n", ret); exit(1); }
+	printf("Starting %zd threads.\n", global_item_size);
+
+	// Copy result to host
+	ret = clEnqueueReadBuffer(command_queue, headerHashmobj, CL_TRUE, 0, 32 * sizeof(uint8_t), headerHash, 0, NULL, NULL);
+	if (ret != CL_SUCCESS) { printf("failed to read header hash from buffer: %d\n", ret); exit(1); }
+	ret = clEnqueueReadBuffer(command_queue, nonceOutmobj, CL_TRUE, 0, 8 * sizeof(uint8_t), nonceOut, 0, NULL, NULL);
+	if (ret != CL_SUCCESS) { printf("failed to read nonce from buffer: %d\n", ret); exit(1); }
+
+	// Did we find one?
+	i = 0;
+	while (target[i] == headerHash[i])
+		i++;
+	if (headerHash[i] < target[i]) {
+		// Display some info about the hash that was found
+		printf("Thread %u found a good hash!\n", nonceOut[0] * 256 + nonceOut[1]);
+
+		printf("Header: [");
+		for (i = 0; i < 10; i++) {
+			printf("%u ", blockHeader[i]);
+		}
+		printf("... %u]\n", blockHeader[79]);
+
+		printf("Hash: [");
+		for (i = 0; i < 10; i++) {
+			printf("%u ", headerHash[i]);
+		}
+		printf("... %u]\n", headerHash[31]);
+
+		printf("Nonce: [");
+		for (i = 0; i < 7; i++) {
+			printf("%u ", nonceOut[i]);
+		}
+		printf("%u]\n", nonceOut[7]);
+
+		// Copy nonce to block
+		for (i = 0; i < 8; i++)
+			block[i + 32] = nonceOut[i];
+
+		submit_block(curl, block, blocklen);
+		printf("\n");
+	} else {
+		printf("No hash was found. Fetching new block.\n");
+		// Hashrate is inaccurate if a block was found
+		double run_time_seconds = (double)(clock() - startTime) / CLOCKS_PER_SEC;
+		double hash_rate = (iter_per_thread*global_item_size) / (run_time_seconds*1000000);
+		printf("Mined for %.2f seconds at %.3f MH/s\n\n", run_time_seconds, hash_rate);
+		// TODO: Print est time until next block (target difficulty / hashrate
+		return hash_rate;
+	}
+	return -1;
 }

--- a/gpu-miner.cl
+++ b/gpu-miner.cl
@@ -60,20 +60,22 @@ __kernel void nonceGrind(__global uchar *headerIn, __global uchar *hashOut, __gl
 	}
 }
 
-// Implementations of memset and memcopy
-void *memset( __private void *s, __private int c, __private size_t n) {
+// Implementations of clmemset and memcopy
+void *clmemset( __private void *s, __private int c, __private size_t n) {
 	uchar *p = s;
-	while(n--)
+	while(n--) {
 		*p++ = (uchar)c;
+	}
 	return s;
 }
 
-void memcpy( __private void *dest, __private const void *src, __private size_t num) {
+void clmemcpy( __private void *dest, __private const void *src, __private size_t num) {
 	int i = 0 ;
 	char *dest8 = (char*)dest;
 	char *src8 = (char*)src;
-	for (int i = 0; i < num; i++)
+	for (int i = 0; i < num; i++) {
 		dest8[i] = src8[i];
+	}
 }
 
 // the code taken from offical Blake2b C reference:
@@ -247,7 +249,7 @@ static inline ulong rotr64( __private const ulong w, __private const unsigned c 
   return ( w >> c ) | ( w << ( 64 - c ) );
 }
 
-// prevents compiler optimizing out memset()
+// prevents compiler optimizing out clmemset()
 static inline void secure_zero_memory( __private void *v, __private size_t n )
 {
   volatile uchar *p = ( volatile uchar * )v;
@@ -319,7 +321,7 @@ static inline int blake2b_increment_counter( __private blake2b_state *S, __priva
 
 static inline int blake2b_init0( __private blake2b_state *S )
 {
-	memset( S, 0, sizeof( blake2b_state ) );
+	clmemset( S, 0, sizeof( blake2b_state ) );
 
 	for( int i = 0; i < 8; ++i ) S->h[i] = blake2b_IV[i];
 
@@ -352,9 +354,9 @@ int blake2b_init( __private blake2b_state *S )
 	store64( &P->node_offset, 0 );
 	P->node_depth = 0;
 	P->inner_length = 0;
-	memset( P->reserved, 0, sizeof( P->reserved ) );
-	memset( P->salt,		 0, sizeof( P->salt ) );
-	memset( P->personal, 0, sizeof( P->personal ) );
+	clmemset( P->reserved, 0, sizeof( P->reserved ) );
+	clmemset( P->salt,		 0, sizeof( P->salt ) );
+	clmemset( P->personal, 0, sizeof( P->personal ) );
 	return blake2b_init_param( S, P );
 }
 
@@ -375,16 +377,16 @@ int blake2b_init_key( __private blake2b_state *S, __private const uchar outlen, 
 	store64( &P->node_offset, 0 );
 	P->node_depth		= 0;
 	P->inner_length	= 0;
-	memset( P->reserved, 0, sizeof( P->reserved ) );
-	memset( P->salt,		 0, sizeof( P->salt ) );
-	memset( P->personal, 0, sizeof( P->personal ) );
+	clmemset( P->reserved, 0, sizeof( P->reserved ) );
+	clmemset( P->salt,		 0, sizeof( P->salt ) );
+	clmemset( P->personal, 0, sizeof( P->personal ) );
 
 	if( blake2b_init_param( S, P ) < 0 ) return -1;
 
 	{
 		uchar block[BLAKE2B_BLOCKBYTES];
-		memset( block, 0, BLAKE2B_BLOCKBYTES );
-		memcpy( block, key, keylen );
+		clmemset( block, 0, BLAKE2B_BLOCKBYTES );
+		clmemcpy( block, key, keylen );
 		blake2b_update( S, block, BLAKE2B_BLOCKBYTES );
 		secure_zero_memory( block, BLAKE2B_BLOCKBYTES ); // Burn the key from stack
 	}
@@ -464,18 +466,18 @@ int blake2b_update( __private blake2b_state *S, __private const uchar *in, __pri
 
 		if( inlen > fill )
 		{
-			memcpy( S->buf + left, in, fill ); // Fill buffer
+			clmemcpy( S->buf + left, in, fill ); // Fill buffer
 			S->buflen += fill;
 			blake2b_increment_counter( S, BLAKE2B_BLOCKBYTES );
 			blake2b_compress( S, S->buf ); // Compress
-			memcpy( S->buf, S->buf + BLAKE2B_BLOCKBYTES, BLAKE2B_BLOCKBYTES ); // Shift buffer left
+			clmemcpy( S->buf, S->buf + BLAKE2B_BLOCKBYTES, BLAKE2B_BLOCKBYTES ); // Shift buffer left
 			S->buflen -= BLAKE2B_BLOCKBYTES;
 			in += fill;
 			inlen -= fill;
 		}
 		else // inlen <= fill
 		{
-			memcpy( S->buf + left, in, inlen );
+			clmemcpy( S->buf + left, in, inlen );
 			S->buflen += inlen; // Be lazy, do not compress
 			in += inlen;
 			inlen -= inlen;
@@ -495,18 +497,18 @@ int blake2b_final( __private blake2b_state *S, __private uchar *out )
 		blake2b_increment_counter( S, BLAKE2B_BLOCKBYTES );
 		blake2b_compress( S, S->buf );
 		S->buflen -= BLAKE2B_BLOCKBYTES;
-		memcpy( S->buf, S->buf + BLAKE2B_BLOCKBYTES, S->buflen );
+		clmemcpy( S->buf, S->buf + BLAKE2B_BLOCKBYTES, S->buflen );
 	}
 
 	blake2b_increment_counter( S, S->buflen );
 	blake2b_set_lastblock( S );
-	memset( S->buf + S->buflen, 0, 2 * BLAKE2B_BLOCKBYTES - S->buflen ); // Padding
+	clmemset( S->buf + S->buflen, 0, 2 * BLAKE2B_BLOCKBYTES - S->buflen ); // Padding
 	blake2b_compress( S, S->buf );
 
 	for( int i = 0; i < 8; ++i ) // Output full hash to temp buffer
 		store64( buffer + sizeof( S->h[i] ) * i, S->h[i] );
 
-	memcpy( out, buffer, 32 );
+	clmemcpy( out, buffer, 32 );
 	return 0;
 }
 

--- a/gpu-miner.cl
+++ b/gpu-miner.cl
@@ -1,10 +1,11 @@
 int blake2b( uchar *out, uchar *in );
 
 // The kernel that grinds nonces until it finds a hash below the target
-__kernel void nonceGrind(__global uchar *headerIn, __global uchar *hashOut, __global uchar *targ, __global uchar *nonceOut, __global bool *nonceOutLock) {
+__kernel void nonceGrind(__global uchar *headerIn, __global uchar *hashOut, __global uchar *targ, __global uchar *nonceOut, __global bool *nonceOutLock, __global uint *numItersIn) {
 	private uchar blockHeader[80];
 	private uchar headerHash[32];
 	private uchar target[32];
+	private uint numOuterIter = *numItersIn / 256;
 	headerHash[0] = 255;
 
 	// Copy header to private memory
@@ -23,7 +24,7 @@ __kernel void nonceGrind(__global uchar *headerIn, __global uchar *hashOut, __gl
 	}
 
 	// Grind nonce values
-	for (i = 0; i < 8; i++) {
+	for (i = 0; i < numOuterIter; i++) {
 		// inc nonce
 		blockHeader[38] = i;
 		for (j = 0; j < 256; j++) {

--- a/network.c
+++ b/network.c
@@ -11,6 +11,8 @@ struct inData {
 
 // Write network data to an array of bytes
 size_t writefunc(void *ptr, size_t size, size_t nmemb, struct inData *in) {
+	if (in == NULL)
+		return size*nmemb;
 	size_t new_len = size*nmemb;
 	in->bytes = (uint8_t*)malloc(new_len);
 	if (in->bytes == NULL) {
@@ -37,6 +39,7 @@ void get_block_for_work(CURL *curl, uint8_t *target, uint8_t *header, uint8_t **
 		res = curl_easy_perform(curl);
 		if(res != CURLE_OK) {
 			fprintf(stderr, "Failed to get block for work, curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+			fprintf(stderr, "Are you sure that siad is running?\n");
 			exit(1);
 		}
 		if (in.len < 152) {
@@ -71,6 +74,9 @@ void submit_block(CURL *curl, uint8_t *block, size_t blocklen) {
 		curl_easy_setopt(curl, CURLOPT_POST, 1);
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, numBytes);
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, block);
+		// Prevent printing to stdout
+		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+		curl_easy_setopt(curl, CURLOPT_WRITEDATA, NULL);
 
 		res = curl_easy_perform(curl);
 		if (res != CURLE_OK) {


### PR DESCRIPTION
When run, the miner will experiment with different global_item_sizes (essentially number of threads) and search for a near optimal number of threads. Each run may result in a different number of threads (e.g. 2048 one run and 4096 the next) because of some variance in speed from call to call. This barely impacts performance because 4096 threads is like calling 2048 threads twice.

The program then tunes the work done in each thread such that every call takes about 3 seconds.

The program prints the current hashrate and the number of blocks mined, updating this line every 3 seconds instead of printing a new line every 3 seconds. The only extra lines that get printed are when the program is searching for the 'optimal' thread count. 
