### PR TITLE
Add -H (specify hostname) option.

### DIFF
--- a/network.c
+++ b/network.c
@@ -36,12 +36,12 @@ int check_http_response(CURL *curl) {
 	return 0;
 }
 
-// set_port establishes the port that siad is on.
-void set_port(char *port) {
-	bfw_url = malloc(29 + strlen(port));
-	submit_url = malloc(28 + strlen(port));
-	sprintf(bfw_url, "localhost%s/miner/headerforwork", port);
-	sprintf(submit_url, "localhost%s/miner/submitheader", port);
+// set_host establishes the port that siad is on.
+void set_host(char *host, char *port) {
+	bfw_url = malloc(21 + strlen(host) + strlen(port));
+	submit_url = malloc(20 + strlen(host) + strlen(port));
+	sprintf(bfw_url, "%s%s/miner/headerforwork", host, port);
+	sprintf(submit_url, "%s%s/miner/submitheader", host, port);
 }
 
 // Write network data to a buffer (inBuf)

--- a/network.c
+++ b/network.c
@@ -36,7 +36,7 @@ int check_http_response(CURL *curl) {
 	return 0;
 }
 
-// set_host establishes the port that siad is on.
+// set_host establishes the hostname and port that siad is on.
 void set_host(char *host, char *port) {
 	bfw_url = malloc(21 + strlen(host) + strlen(port));
 	submit_url = malloc(20 + strlen(host) + strlen(port));

--- a/network.h
+++ b/network.h
@@ -1,6 +1,6 @@
 #include <stdint.h>
 
-void set_port(char *port);
+void set_host(char *host, char *port);
 void init_network();
 int get_header_for_work(uint8_t *target, uint8_t *header);
 int submit_header(uint8_t *header);

--- a/sia-gpu-miner.c
+++ b/sia-gpu-miner.c
@@ -322,6 +322,7 @@ int main(int argc, char *argv[]) {
 	cl_uint platformid = 0, deviceidx = 0;
 	int i;
 	unsigned cycles_per_iter;
+	char hostname[128] = "localhost";
 	char port_number[7] = ":9980";
 	double hash_rate;
 
@@ -343,6 +344,8 @@ int main(int argc, char *argv[]) {
 			printf("\t I - intensity: This is the amount of work sent to the GPU in one batch.\n");
 			printf("\t\tInterpretation is 2^intensity; the default is 16. Lower if GPU crashes or\n");
 			printf("\t\tif more desktop interactivity is desired. Highest hashrate is typically at 22-25.\n");
+			printf("\n");
+			printf("\t H - host: which host name to use when talking to the siad api. (default: %s)\n", hostname);
 			printf("\n");
 			printf("\t P - port: which port to use when talking to the siad api. (e.g. -p :9980)\n");
 			printf("\n");
@@ -415,6 +418,14 @@ int main(int argc, char *argv[]) {
 			}
 			printf("Cycles per iteration set to %u\n", cycles_per_iter);
 			break;
+		case 'H':
+			if (++i >= argc) {
+				printf("Please pass in a host name following your flag (e.g. -H localhost)\n");
+				exit(1);
+			}
+			strcpy(hostname, argv[i]);
+			printf("Host name set to %s\n", hostname);
+			break;
 		case 'P':
 			if (++i >= argc) {
 				printf("Please pass in a port number following your flag (e.g. -P :9980)\n");
@@ -436,7 +447,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	// Set siad URL.
-	set_port(port_number);
+	set_host(hostname, port_number);
 
 	// Load kernel source file.
 	printf("Initializing...\n");


### PR DESCRIPTION
Currently the host name of Sia daemon is pre-defined as `localhost`.
If a miner want to run a multiple mining nodes that is connected to a single parent node that serves Sia daemon (`siad`), one should modify the source code to point the host name (or IP address) of siad host.

In this pull request, you can specify a host name of siad node by command line argument (`-H` option), which hopefully useful for miners running multiple mining nodes.
# 

Additionally, I am suggesting that you should not prefix with `:` to port number.
`-P :9880` should be `-P 9880` which is easy to verify the validity of port number (use `atoi(argv[i])` instead).
