### PR TITLE
update readme with miner module requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ sudo ln -s /usr/lib/x86_64-linux-gnu/libOpenCL.so.1 /usr/lib/libOpenCL.so
 ## How to Use
 1) Build the miner by running `make`.
 
-2) Make sure you have a recent version of Sia installed and running.
+2) Make sure you have a recent version of Sia installed and running. You must run Sia with the `miner` module enabled, which is not enabled by default in `Sia-UI`. To run with the miner module, use `siad`'s `-M` flag and specify the `m` module. See `siad modules`.
 
 3) Run the miner by running `./gpu-miner`. It will mine blocks until killed with Ctrl-C.
 


### PR DESCRIPTION
See #64. Users are not aware that they must run a `miner` module, this PR updates the docs to indicate such.